### PR TITLE
Allow function creating tasks

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@ const Spinnies = require("spinnies");
 function taskz(tasks, options = { parallel: false }) {
   return {
     run: async (
-      level = 0,
       ctx = {},
+      level = 0,
       spinnies = new Spinnies({ succeedColor: "green", succeedPrefix: "✔" })
     ) =>
       (options.parallel ? runParallel : runSequence)(
@@ -59,7 +59,7 @@ async function runTask({ t, i, level, ctx, spinnies, tasks }) {
       text: `→ ${t.text}${counter}`,
       status: "stopped"
     });
-    await t.tasks.run(level + 1, ctx, spinnies);
+    await t.tasks.run(ctx, level + 1, spinnies);
   } else {
     // Run one task
     try {

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ function taskz(tasks, options = { parallel: false }) {
       spinnies = new Spinnies({ succeedColor: "green", succeedPrefix: "✔" })
     ) =>
       (options.parallel ? runParallel : runSequence)(
-        tasks,
+        typeof tasks === 'function' ? tasks(ctx) : tasks,
         level,
         ctx,
         spinnies

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ function taskz(tasks, options = { parallel: false }) {
       level = 0,
       spinnies = new Spinnies({ succeedColor: "green", succeedPrefix: "✔" })
     ) =>
-      (options.parallel ? runParallel : runSequence)(
+       (options.parallel ? runParallel : runSequence)(
         typeof tasks === 'function' ? tasks(ctx) : tasks,
         level,
         ctx,
@@ -49,10 +49,12 @@ async function runSequence(tasks, level, ctx, spinnies) {
 async function runTask({ t, i, level, ctx, spinnies, tasks }) {
   const id = String(i + Math.random());
   const counter = chalk.dim.grey(` [${i + 1}/${tasks.length}]`);
-  spinnies.add(id, { text: `${t.text}${counter}`, indent: level });
-  ctx.text = val => {
+  const setText = val => {
     spinnies.update(id, { text: `${val}${counter}` });
   };
+
+  spinnies.add(id, { text: `${t.text}${counter}`, indent: level });
+
   if (t.tasks) {
     // Subtasks
     spinnies.update(id, {
@@ -63,7 +65,7 @@ async function runTask({ t, i, level, ctx, spinnies, tasks }) {
   } else {
     // Run one task
     try {
-      await t.task(ctx);
+      await t.task(ctx, setText);
       spinnies.succeed(id, { text: chalk.reset(spinnies.pick(id).text) });
     } catch (e) {
       spinnies.fail(id, { text: chalk.reset(`${e.message}${counter}`) });


### PR DESCRIPTION
Hi there, I needed some adjustments to you (very helpful) library I thought you'd be interested in (I separated them into 3 commits so you can also just pick what you want).

**The thing I needed:** Instead of only being able to pass an array of tasks you can now pass a function (that receives `ctx` and construct the array

```js
taskz(ctx => [{}, {}, {}]
```

Things I felt fit (but is breaking):
- Changed the order of arguments as it's much ore likely to pass `ctx` (not needing to set level and the spinner as they're used 99% internally, one could even argue to put up a facade that only receives the `ctx`)
- I accidentally overwrote the `text` fn so I thought it may be better to have a separate fn to set the text on the spinner (can also be used for color and other stuff later)

Again thanks for making this!
