### PR TITLE
Allow function creating tasks array

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ function taskz(tasks, options = { parallel: false }) {
       spinnies = new Spinnies({ succeedColor: "green", succeedPrefix: "✔" })
     ) =>
       (options.parallel ? runParallel : runSequence)(
-        tasks,
+        typeof tasks === 'function' ? tasks(ctx) : tasks,
         level,
         ctx,
         spinnies


### PR DESCRIPTION
Part 1 of https://github.com/rap2hpoutre/taskz/pull/6

Instead of only being able to pass an array of tasks you can now pass a function (that receives ctx and construct the array
```js
taskz(ctx => [{}, {}, {}]
```