### PR TITLE
Reorder arguments to pass context easier

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@ const Spinnies = require("spinnies");
 function taskz(tasks, options = { parallel: false }) {
   return {
     run: async (
-      level = 0,
       ctx = {},
+      level = 0,
       spinnies = new Spinnies({ succeedColor: "green", succeedPrefix: "✔" })
     ) =>
       (options.parallel ? runParallel : runSequence)(
@@ -59,7 +59,7 @@ async function runTask({ t, i, level, ctx, spinnies, tasks }) {
       text: `→ ${t.text}${counter}`,
       status: "stopped"
     });
-    await t.tasks.run(level + 1, ctx, spinnies);
+    await t.tasks.run(ctx, level + 1, spinnies);
   } else {
     // Run one task
     try {


### PR DESCRIPTION
Part 2 of https://github.com/rap2hpoutre/taskz/pull/6

Changed the order of arguments as it's much ore likely to pass `ctx` (not needing to set level and the spinner as they're used 99% internally, one could even argue to put up a facade that only receives the `ctx`)