### PR TITLE
Replace text() context fn with separate fn

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,19 +53,19 @@ Replace `task` by `tasks` and call `taskz` function.
 ```js
 const myTasks = taskz([
   { text: "task 1", task: () => { /* ... */ } },
-  { 
-    text: "task 2 with subtasks", 
+  {
+    text: "task 2 with subtasks",
     tasks: taskz([
       { text: "task 2.1", task: () => { /* ... */ } },
       { text: "task 2.2", task: () => { /* ... */ } }
-    ]) 
+    ])
   }
 ]);
 ```
 
 ### Concurrent tasks (parallelism)
 
-Add `{ parallel: true }` as a second parameter in `taskz`. 
+Add `{ parallel: true }` as a second parameter in `taskz`.
 
 ```js
 const myTasks = taskz([
@@ -99,13 +99,13 @@ const myTasks = taskz([
 
 ```js
 const myTasks = taskz([
-  { 
-    text: "task 1", 
-    task: ctx => { ctx.val = "foo" } 
+  {
+    text: "task 1",
+    task: ctx => { ctx.val = "foo" }
   },
-  { 
-    text: "task 2", 
-    task: ctx => { doSomethingWith(ctx.val) } 
+  {
+    text: "task 2",
+    task: ctx => { doSomethingWith(ctx.val) }
   }
 ]);
 ```
@@ -116,10 +116,10 @@ const myTasks = taskz([
 const myTasks = taskz([
   {
     text: "my subtask 2",
-    task: async ctx => {
-      ctx.text("my subtask 2 foo");
+    task: async (ctx, setText) => {
+      setText("my subtask 2 foo");
       await new Promise(resolve => setTimeout(resolve, 200));
-      ctx.text("my subtask 2 bar");
+      setText(kleur.magenta("my subtask 2 bar");
     }
   }
 ]);

--- a/examples/sequence.js
+++ b/examples/sequence.js
@@ -1,4 +1,5 @@
 const taskz = require("../index.js");
+const kleur = require('kleur')
 
 function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
@@ -29,13 +30,15 @@ const tasks = taskz([
       },
       {
         text: "",
-        task: async ctx => {
-          const frames = ["foo", "bar", "baz"];
+        task: async (ctx, setText) => {
+          const frames = ["cyan", "red", "magenta"];
           for (let i in frames) {
-            ctx.text(`my subtask 2 ${frames[i]}`);
+            const colour = frames[i]
+
+            setText(kleur[colour](`my subtask 2 now in ${colour}`));
             await sleep(750);
           }
-          ctx.text("my subtask 2 done");
+          setText("my subtask 2 done");
         }
       }
     ])

--- a/index.js
+++ b/index.js
@@ -50,9 +50,11 @@ async function runTask({ t, i, level, ctx, spinnies, tasks }) {
   const id = String(i + Math.random());
   const counter = grey().dim(` [${i + 1}/${tasks.length}]`);
   spinnies.add(id, { text: `${t.text}${counter}`, indent: level });
-  ctx.text = val => {
+
+  const setText = val => {
     spinnies.update(id, { text: `${val}${counter}` });
   };
+
   if (t.tasks) {
     // Subtasks
     spinnies.update(id, {
@@ -63,7 +65,7 @@ async function runTask({ t, i, level, ctx, spinnies, tasks }) {
   } else {
     // Run one task
     try {
-      await t.task(ctx);
+      await t.task(ctx, setText);
       spinnies.succeed(id, { text: reset(spinnies.pick(id).text) });
     } catch (e) {
       spinnies.fail(id, { text: reset(`${e.message}${counter}`) });


### PR DESCRIPTION
Part 3 of https://github.com/rap2hpoutre/taskz/pull/6

I accidentally overwrote the text fn so I thought it may be better to have a separate fn to set the text on the spinner (can also be used for color and other stuff later)

This keeps the context clean and separated from things the user might or might not write during task executions and will also not override a predefined user context.

It should still work but slightly different:
```js
const myTasks = taskz([
  {
    text: "my subtask 2",
    task: async (ctx, setText) => {
      setText("my subtask 2 foo");
      await new Promise(resolve => setTimeout(resolve, 200));
      setText("my subtask 2 bar");
    }
  }
]);
```

I adapted the readme + examples. However feel free to decide whether to take it or not 😉 